### PR TITLE
feat(backend): Refactoring Service Interfaces Using ICrudServices

### DIFF
--- a/coffee-shop-backend.Tests/Business/Concreates/OrderServicesTest.cs
+++ b/coffee-shop-backend.Tests/Business/Concreates/OrderServicesTest.cs
@@ -41,7 +41,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = orderServices.AddOrder(request, token);
+        var result = orderServices.Add(request, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -68,7 +68,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = orderServices.AddOrder(request, token);
+        var result = orderServices.Add(request, token);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -88,7 +88,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
 
         var token = "invalid_token";
 
-        var result = orderServices.AddOrder(request, token);
+        var result = orderServices.Add(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -145,7 +145,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
             Status = EnumOrderStatus.Waiting
         };
 
-        var result = orderServices.UpdateOrderStatus(request, 1, token);
+        var result = orderServices.Update(request, 1, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -162,7 +162,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
             Status = EnumOrderStatus.Waiting
         };
 
-        var result = orderServices.UpdateOrderStatus(request, 1, token);
+        var result = orderServices.Update(request, 1, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -185,7 +185,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
             Status = EnumOrderStatus.Waiting
         };
 
-        var result = orderServices.UpdateOrderStatus(request, 1, token);
+        var result = orderServices.Update(request, 1, token);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -208,7 +208,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
             Status = EnumOrderStatus.Waiting
         };
 
-        var result = orderServices.UpdateOrderStatus(request, 1, token);
+        var result = orderServices.Update(request, 1, token);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -233,7 +233,7 @@ public class OrderServicesTest : IClassFixture<OrderServicesFixture>
             Status = EnumOrderStatus.Waiting
         };
 
-        var result = orderServices.UpdateOrderStatus(request, 1, token);
+        var result = orderServices.Update(request, 1, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }

--- a/coffee-shop-backend.Tests/Business/Concreates/ProductServicesTest.cs
+++ b/coffee-shop-backend.Tests/Business/Concreates/ProductServicesTest.cs
@@ -41,7 +41,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
             ImageUrl = "test_image_url",
         };
 
-        var result = productServices.AddProduct(request, token);
+        var result = productServices.Add(request, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -61,7 +61,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
             ImageUrl = "test_image_url",
         };
 
-        var result = productServices.AddProduct(request, token);
+        var result = productServices.Add(request, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -86,7 +86,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
             ImageUrl = "test_image_url",
         };
 
-        var result = productServices.AddProduct(request, token);
+        var result = productServices.Add(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -106,7 +106,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
             ImageUrl = "test_image_url",
         };
 
-        var result = productServices.AddProduct(request, token);
+        var result = productServices.Add(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -123,7 +123,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.GetProductById(1, token);
+        var result = productServices.GetById(1, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -135,7 +135,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.GetProductById(1, token);
+        var result = productServices.GetById(1, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -147,7 +147,7 @@ public class ProductServicesTest: IClassFixture<ProductServicesFixture>
 
         var token = "test_token";
 
-        var result = productServices.GetProductById(1, token);
+        var result = productServices.GetById(1, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -165,7 +165,7 @@ public void ProductServices_DeleteProductById()
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.DeleteProductById(1, token);
+        var result = productServices.DeleteById(1, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -177,7 +177,7 @@ public void ProductServices_DeleteProductById()
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.DeleteProductById(1, token);
+        var result = productServices.DeleteById(1, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -194,7 +194,7 @@ public void ProductServices_DeleteProductById()
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.DeleteProductById(1, token);
+        var result = productServices.DeleteById(1, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -211,7 +211,7 @@ public void ProductServices_DeleteProductById()
 
         var token = TestHelper.GenerateJwtToken(1, "test_email");
 
-        var result = productServices.DeleteProductById(1, token);
+        var result = productServices.DeleteById(1, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -221,7 +221,7 @@ public void ProductServices_DeleteProductById()
     {
         var productServices = _fixture.CreateProductServices();
 
-        var result = productServices.DeleteProductById(1, "test_token");
+        var result = productServices.DeleteById(1, "test_token");
 
         Assert.IsType<UnauthorizedResult>(result);
     }

--- a/coffee-shop-backend.Tests/Business/Concreates/StockServicesTest.cs
+++ b/coffee-shop-backend.Tests/Business/Concreates/StockServicesTest.cs
@@ -41,7 +41,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             ProductId = 1,
         };
 
-        var result = stockServices.AddStock(request, token);
+        var result = stockServices.Add(request, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -59,7 +59,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             ProductId = 1,
         };
 
-        var result = stockServices.AddStock(request, token);
+        var result = stockServices.Add(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -77,7 +77,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             ProductId = 1,
         };
 
-        var result = stockServices.AddStock(request, token);
+        var result = stockServices.Add(request, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -100,7 +100,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             ProductId = 1,
         };
 
-        var result = stockServices.AddStock(request, token);
+        var result = stockServices.Add(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -123,7 +123,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             ProductId = 1,
         };
 
-        var result = stockServices.AddStock(request, token);
+        var result = stockServices.Add(request, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -152,7 +152,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             Amount = 2,
         };
 
-        var result = stockServices.UpdateStock(request, token);
+        var result = stockServices.Update(request, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -170,7 +170,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             Amount = 2,
         };
 
-        var result = stockServices.UpdateStock(request, token);
+        var result = stockServices.Update(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -188,7 +188,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             Amount = 2,
         };
 
-        var result = stockServices.UpdateStock(request, token);
+        var result = stockServices.Update(request, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -211,7 +211,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             Amount = 2,
         };
 
-        var result = stockServices.UpdateStock(request, token);
+        var result = stockServices.Update(request, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -234,7 +234,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
             Amount = 2,
         };
 
-        var result = stockServices.UpdateStock(request, token);
+        var result = stockServices.Update(request, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -257,7 +257,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = stockServices.DeleteStock(1, token);
+        var result = stockServices.DeleteById(1, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -267,7 +267,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
     {
         var stockServices = _fixture.CreateStockServices();
 
-        var result = stockServices.DeleteStock(1, "invalid_token");
+        var result = stockServices.DeleteById(1, "invalid_token");
 
         Assert.IsType<UnauthorizedResult>(result);
     }
@@ -284,7 +284,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = stockServices.DeleteStock(1, token);
+        var result = stockServices.DeleteById(1, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -306,7 +306,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = stockServices.GetStockById(1, token);
+        var result = stockServices.GetById(1, token);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -323,7 +323,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
 
         var token = TestHelper.GenerateJwtToken(1, user.Email);
 
-        var result = stockServices.GetStockById(1, token);
+        var result = stockServices.GetById(1, token);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -335,7 +335,7 @@ public class StockServicesTest: IClassFixture<StockServicesFixture>
 
         var token = "invalid_token";
 
-        var result = stockServices.GetStockById(1, token);
+        var result = stockServices.GetById(1, token);
 
         Assert.IsType<UnauthorizedResult>(result);
     }

--- a/coffee-shop-backend.Tests/Controllers/OrderControllerTest.cs
+++ b/coffee-shop-backend.Tests/Controllers/OrderControllerTest.cs
@@ -14,14 +14,14 @@ public class OrderControllerTest
     {
         var orderServicesMock = new Mock<IOrderServices>();
 
-        orderServicesMock.Setup(x => x.AddOrder(It.IsAny<AddOrderRequest>(), It.IsAny<string>()))
+        orderServicesMock.Setup(x => x.Add(It.IsAny<AddOrderRequest>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("Success"));
 
         orderServicesMock.Setup(x => x.GetOrdersByUserId(It.IsAny<string>()))
             .Returns(new OkObjectResult("Success"));
 
         orderServicesMock.Setup(x =>
-                x.UpdateOrderStatus(It.IsAny<UpdateOrderStatusRequest>(), It.IsAny<long>(), It.IsAny<string>()))
+                x.Update(It.IsAny<UpdateOrderStatusRequest>(), It.IsAny<long>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("Success"));
 
         _orderServices = orderServicesMock.Object;

--- a/coffee-shop-backend.Tests/Controllers/ProductControllerTest.cs
+++ b/coffee-shop-backend.Tests/Controllers/ProductControllerTest.cs
@@ -14,13 +14,13 @@ public class ProductControllerTest
     {
         var mockProductServices = new Mock<IProductServices>();
 
-        mockProductServices.Setup(x => x.AddProduct(It.IsAny<AddProductRequest>(), It.IsAny<string>()))
+        mockProductServices.Setup(x => x.Add(It.IsAny<AddProductRequest>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("AddProduct"));
 
-        mockProductServices.Setup(x => x.GetProductById(It.IsAny<long>(), It.IsAny<string>()))
+        mockProductServices.Setup(x => x.GetById(It.IsAny<long>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("GetProductById"));
 
-        mockProductServices.Setup(x => x.DeleteProductById(It.IsAny<long>(), It.IsAny<string>()))
+        mockProductServices.Setup(x => x.DeleteById(It.IsAny<long>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("DeleteProductById"));
 
         mockProductServices.Setup(x => x.GetProductsByPage(It.IsAny<int>(), It.IsAny<string>()))

--- a/coffee-shop-backend.Tests/Controllers/StockControllerTest.cs
+++ b/coffee-shop-backend.Tests/Controllers/StockControllerTest.cs
@@ -15,16 +15,16 @@ public class StockControllerTest
     {
         var mockStockServices = new Mock<IStockServices>();
 
-        mockStockServices.Setup(services => services.AddStock(It.IsAny<AddStockRequest>(), It.IsAny<string>()))
+        mockStockServices.Setup(services => services.Add(It.IsAny<AddStockRequest>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("AddStock"));
 
-        mockStockServices.Setup(services => services.UpdateStock(It.IsAny<UpdateStockRequest>(), It.IsAny<string>()))
+        mockStockServices.Setup(services => services.Update(It.IsAny<UpdateStockRequest>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("UpdateStock"));
 
-        mockStockServices.Setup(services => services.DeleteStock(It.IsAny<long>(), It.IsAny<string>()))
+        mockStockServices.Setup(services => services.DeleteById(It.IsAny<long>(), It.IsAny<string>()))
             .Returns(new OkObjectResult("DeleteStock"));
 
-        mockStockServices.Setup(services => services.GetStockById(It.IsAny<long>(), It.IsAny<string>()))
+        mockStockServices.Setup(services => services.GetById(It.IsAny<long>(), It.IsAny<string>()))
             .Returns( new OkObjectResult("GetStockById"));
 
         _mockStockServices = mockStockServices.Object;

--- a/coffee-shop-backend/Business/Abstracts/ICrudServices.cs
+++ b/coffee-shop-backend/Business/Abstracts/ICrudServices.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace coffee_shop_backend.Business.Abstracts;
+
+public interface ICrudServices<TAddRequest, TUpdateRequest>
+{
+    public IActionResult Add(TAddRequest request, string token);
+    public IActionResult Update(TUpdateRequest request, string token);
+    public IActionResult DeleteById(long id, string token);
+    public IActionResult GetById(long id, string token);
+}

--- a/coffee-shop-backend/Business/Abstracts/IOrderServices.cs
+++ b/coffee-shop-backend/Business/Abstracts/IOrderServices.cs
@@ -3,9 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace coffee_shop_backend.Business.Abstracts;
 
-public interface IOrderServices
+public interface IOrderServices: ICrudServices<AddOrderRequest, UpdateOrderStatusRequest>
 {
-    public IActionResult AddOrder(AddOrderRequest request, string token);
     public IActionResult GetOrdersByUserId(string token);
-    public IActionResult UpdateOrderStatus(UpdateOrderStatusRequest request,long orderId ,string token);
+    public IActionResult Update(UpdateOrderStatusRequest request,long orderId ,string token);
 }

--- a/coffee-shop-backend/Business/Abstracts/IProductServices.cs
+++ b/coffee-shop-backend/Business/Abstracts/IProductServices.cs
@@ -3,11 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace coffee_shop_backend.Business.Abstracts;
 
-public interface IProductServices
+public interface IProductServices: ICrudServices<AddProductRequest, UpdateProductRequest>
 {
-    public IActionResult AddProduct(AddProductRequest request, string token);
-    public IActionResult GetProductById(long id, string token);
-    public IActionResult DeleteProductById(long id, string token);
     public IActionResult GetProductsByPage(int page, string token);
     public IActionResult GetAllProducts(string token);
 }

--- a/coffee-shop-backend/Business/Abstracts/IStockServices.cs
+++ b/coffee-shop-backend/Business/Abstracts/IStockServices.cs
@@ -1,13 +1,7 @@
 using coffee_shop_backend.Dto.Stock;
-using coffee_shop_backend.Entitys.Concreates;
-using Microsoft.AspNetCore.Mvc;
 
 namespace coffee_shop_backend.Business.Abstracts;
 
-public interface IStockServices
+public interface IStockServices: ICrudServices<AddStockRequest, UpdateStockRequest>
 {
-    public IActionResult AddStock(AddStockRequest request, string token);
-    public IActionResult UpdateStock(UpdateStockRequest request, string token);
-    public IActionResult DeleteStock(long id, string token);
-    public IActionResult GetStockById(long id, string token);
 }

--- a/coffee-shop-backend/Business/Concreates/OrderServices.cs
+++ b/coffee-shop-backend/Business/Concreates/OrderServices.cs
@@ -20,7 +20,7 @@ public class OrderServices: IOrderServices
         _logger = logger;
     }
 
-    public IActionResult AddOrder(AddOrderRequest request, string token)
+    public IActionResult Add(AddOrderRequest request, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -67,6 +67,8 @@ public class OrderServices: IOrderServices
         }
     }
 
+
+
     public IActionResult GetOrdersByUserId(string token)
     {
         if (!_jwtServices.IsTokenValid(token))
@@ -96,7 +98,7 @@ public class OrderServices: IOrderServices
         return new OkObjectResult(new {message = "Orders fetched successfully", success = true, data = ordersWithUserAndProduct});
     }
 
-    public IActionResult UpdateOrderStatus(UpdateOrderStatusRequest request, long orderId, string token)
+    public IActionResult Update(UpdateOrderStatusRequest request, long orderId, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -141,5 +143,20 @@ public class OrderServices: IOrderServices
             _logger.LogError($"Error while updating order status",e);
             return new BadRequestObjectResult(new {message = e.Message, success = false});
         }
+    }
+
+    public IActionResult Update(UpdateOrderStatusRequest request, string token)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IActionResult DeleteById(long id, string token)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IActionResult GetById(long id, string token)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/coffee-shop-backend/Business/Concreates/ProductServices.cs
+++ b/coffee-shop-backend/Business/Concreates/ProductServices.cs
@@ -24,7 +24,7 @@ public class ProductServices: IProductServices
         _logger = logger;
     }
 
-    public IActionResult AddProduct(AddProductRequest request, string token)
+    public IActionResult Add(AddProductRequest request, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -70,7 +70,13 @@ public class ProductServices: IProductServices
         }
     }
 
-    public IActionResult GetProductById(long id, string token)
+    // TODO: Implement this method
+    public IActionResult Update(UpdateProductRequest request, string token)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IActionResult GetById(long id, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -102,7 +108,7 @@ public class ProductServices: IProductServices
         return new OkObjectResult(new { message = "Product found", success = true, data = productWithStock });
     }
 
-    public IActionResult DeleteProductById(long id, string token)
+    public IActionResult DeleteById(long id, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {

--- a/coffee-shop-backend/Business/Concreates/StockServices.cs
+++ b/coffee-shop-backend/Business/Concreates/StockServices.cs
@@ -20,7 +20,7 @@ public class StockServices:IStockServices
         _logger = logger;
     }
 
-    public IActionResult AddStock(AddStockRequest request, string token)
+    public IActionResult Add(AddStockRequest request, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -73,7 +73,7 @@ public class StockServices:IStockServices
         }
     }
 
-    public IActionResult UpdateStock(UpdateStockRequest request, string token)
+    public IActionResult Update(UpdateStockRequest request, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -123,7 +123,7 @@ public class StockServices:IStockServices
        }
     }
 
-    public IActionResult DeleteStock(long id, string token)
+    public IActionResult DeleteById(long id, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {
@@ -154,7 +154,7 @@ public class StockServices:IStockServices
         }
     }
 
-    public IActionResult GetStockById(long id, string token)
+    public IActionResult GetById(long id, string token)
     {
         if (!_jwtServices.IsTokenValid(token))
         {

--- a/coffee-shop-backend/Controllers/OrderController.cs
+++ b/coffee-shop-backend/Controllers/OrderController.cs
@@ -18,7 +18,7 @@ public class OrderController:ControllerBase
     [HttpPost]
     public IActionResult AddOrder([FromBody] AddOrderRequest request, [FromHeader] string token)
     {
-        return _orderServices.AddOrder(request, token);
+        return _orderServices.Add(request, token);
     }
 
     [HttpGet]
@@ -30,7 +30,7 @@ public class OrderController:ControllerBase
     [HttpPatch("{id}")]
     public IActionResult UpdateOrderStatus([FromBody] UpdateOrderStatusRequest request, [FromRoute] long id, [FromHeader] string token)
     {
-        return _orderServices.UpdateOrderStatus(request, id, token);
+        return _orderServices.Update(request, id, token);
     }
 
 }

--- a/coffee-shop-backend/Controllers/ProductController.cs
+++ b/coffee-shop-backend/Controllers/ProductController.cs
@@ -18,19 +18,19 @@ public class ProductController: ControllerBase
     [HttpPost]
     public IActionResult AddProduct([FromBody]AddProductRequest request, [FromHeader] string token)
     {
-        return _productServices.AddProduct(request, token);
+        return _productServices.Add(request, token);
     }
 
     [HttpGet("{id}")]
     public IActionResult GetProductById([FromRoute]long id, [FromHeader]string token)
     {
-        return _productServices.GetProductById(id, token);
+        return _productServices.GetById(id, token);
     }
 
     [HttpDelete("{id}")]
     public IActionResult DeleteProductById([FromRoute]long id, [FromHeader]string token)
     {
-        return _productServices.DeleteProductById(id, token);
+        return _productServices.DeleteById(id, token);
     }
 
     [HttpGet("page/{page}")]

--- a/coffee-shop-backend/Controllers/StockController.cs
+++ b/coffee-shop-backend/Controllers/StockController.cs
@@ -18,25 +18,25 @@ public class StockController: ControllerBase
     [HttpPost]
     public IActionResult AddStock([FromBody]AddStockRequest request, [FromHeader]string token)
     {
-        return _stockServices.AddStock(request, token);
+        return _stockServices.Add(request, token);
     }
 
     [HttpPatch]
     public IActionResult UpdateStock([FromBody]UpdateStockRequest request, [FromHeader]string token)
     {
-        return _stockServices.UpdateStock(request, token);
+        return _stockServices.Update(request, token);
     }
 
     [HttpDelete("{id}")]
     public IActionResult DeleteStock([FromRoute]long id, [FromHeader]string token)
     {
-        return _stockServices.DeleteStock(id, token);
+        return _stockServices.DeleteById(id, token);
     }
 
     [HttpGet("{id}")]
     public IActionResult GetStockById([FromRoute]long id, [FromHeader]string token)
     {
-        return _stockServices.GetStockById(id, token);
+        return _stockServices.GetById(id, token);
     }
 
 

--- a/coffee-shop-backend/Dto/Product/UpdateProductRequest.cs
+++ b/coffee-shop-backend/Dto/Product/UpdateProductRequest.cs
@@ -1,0 +1,7 @@
+namespace coffee_shop_backend.Dto.Product;
+
+// TODO: Add validation attributes
+public class UpdateProductRequest
+{
+
+}


### PR DESCRIPTION
**Description**

This PR aims to prevent code duplication by implementing the ISrockServices, IProductServices, and IOrderServices interfaces using the ICrudServices interface.

**Changes**

- Created a new interface named ICrudServices to represent CRUD (Create, Read, Update, Delete) operations.
- ISrockServices, IProductServices, and IOrderServices interfaces inherit from the ICrudServices interface to include CRUD operations.
- Existing classes were updated to implement these new interfaces.
- Code duplication is prevented by maintaining consistency using the same pattern for CRUD operations.

These changes were made to improve code cleanliness, facilitate maintenance, prevent duplicated structures, and ensure overall consistency and standards.

**Developer Notes**

- The ICrudServices interface encapsulates the general structure of CRUD operations. Each service interface implements customized CRUD operations using this structure.
